### PR TITLE
Fix the NoUpdater parameter

### DIFF
--- a/src/tools/chocolateyInstall.ps1
+++ b/src/tools/chocolateyInstall.ps1
@@ -58,7 +58,7 @@ if ($packageParameters) {
 
     if ($arguments.ContainsKey("NoUpdater")) {
         Write-Host "You want NoUpdater"
-        $customArguments.Add("NOUPDATER", "0")
+        $customArguments.Add("NOUPDATER", "1")
     }
 
     if ($arguments.ContainsKey("NoViewInBrowsers")) {


### PR DESCRIPTION
I like the parameter options, but most of the installer switches are True/1 by default.  NoUpdater is False/0 by default (double-negative).  Have to set it to True/1 when the parameter is chosen.

Not sure why it's showing 32 line changes.  I only made a single character change.
